### PR TITLE
✨ Feat: Add edit mode to scheduled toot v.0.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toots-scheduler",
   "private": true,
-  "version": "0.5.8",
+  "version": "0.6.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ScheduledToots.vue
+++ b/src/components/ScheduledToots.vue
@@ -24,6 +24,14 @@ async function handleDelete(id: string) {
   }
 }
 
+function handleEdit(id: string) {
+  console.log('handleEdit', id);
+  const toot = store.toots.find(t => t.id === id);
+  if (toot) {
+    store.setEditingToot(toot);
+  }
+}
+
 onMounted(() => {
   store.fetchScheduledToots();
 });
@@ -64,6 +72,7 @@ onMounted(() => {
             :language="toot.params?.language"
             :is-loading="store.isLoading"
             :on-delete="handleDelete"
+            :on-edit="handleEdit"
           />
         </TransitionGroup>
       </div>

--- a/src/components/ScheduledToots.vue
+++ b/src/components/ScheduledToots.vue
@@ -25,7 +25,6 @@ async function handleDelete(id: string) {
 }
 
 function handleEdit(id: string) {
-  console.log('handleEdit', id);
   const toot = store.toots.find(t => t.id === id);
   if (toot) {
     store.setEditingToot(toot);

--- a/src/components/TootCard.vue
+++ b/src/components/TootCard.vue
@@ -9,6 +9,7 @@ interface Props {
   language?: string;
   isLoading?: boolean;
   onDelete: (id: string) => Promise<void>;
+  onEdit: (id: string) => void;
 }
 
 const props = defineProps<Props>();
@@ -52,13 +53,22 @@ function getLanguageName(code: string | undefined): string {
         <span class="meta-label">Scheduled for:</span>
         {{ formatDateTime(props.scheduledAt) }}
       </div>
-      <button 
-        class="delete-button" 
-        @click="props.onDelete(props.id)"
-        :disabled="props.isLoading"
-      >
-        {{ props.isLoading ? 'Deleting...' : 'Delete' }}
-      </button>
+      <div class="actions">
+        <button 
+          class="edit-button" 
+          @click="props.onEdit(props.id)"
+          :disabled="props.isLoading"
+        >
+          {{ props.isLoading ? 'Editing...' : 'Edit' }}
+        </button>
+        <button 
+          class="delete-button" 
+          @click="props.onDelete(props.id)"
+          :disabled="props.isLoading"
+        >
+          {{ props.isLoading ? 'Deleting...' : 'Delete' }}
+        </button>
+      </div>
     </div>
 
     <div class="toot-content">{{ props.text }}</div>
@@ -116,6 +126,31 @@ function getLanguageName(code: string | undefined): string {
   margin-top: 0.5rem;
 }
 
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.edit-button {
+  padding: 0.5rem 1rem;
+  background-color: #2b90d9;
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.edit-button:hover:not(:disabled) {
+  background-color: #2577b1;
+}
+
+.edit-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
 .delete-button {
   padding: 0.5rem 1rem;
   background-color: #e74c3c;
@@ -142,6 +177,13 @@ function getLanguageName(code: string | undefined): string {
     align-items: stretch;
   }
   
+  .actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+  
+  .edit-button,
   .delete-button {
     width: 100%;
   }

--- a/src/stores/features.ts
+++ b/src/stores/features.ts
@@ -7,6 +7,17 @@ const STORAGE_KEY = 'masto-publish-later-features';
 export const useFeaturesStore = defineStore('features', () => {
   const features = ref<FeatureGroup[]>([
     {
+      version: '0.6.7',
+      date: '2024-03-19',
+      features: [
+        {
+          id: 'edit-scheduled-toots',
+          title: '🔄 Edit scheduled toots',
+          description: 'Made a typo? No problem! Now you can edit your scheduled toots!',
+        },
+      ],
+    },
+    {
       version: '0.5.7',
       date: '2024-03-18',
       features: [

--- a/src/stores/features.ts
+++ b/src/stores/features.ts
@@ -7,13 +7,24 @@ const STORAGE_KEY = 'masto-publish-later-features';
 export const useFeaturesStore = defineStore('features', () => {
   const features = ref<FeatureGroup[]>([
     {
-      version: '0.6.7',
+      version: '0.6.8',
       date: '2024-03-19',
       features: [
         {
           id: 'edit-scheduled-toots',
           title: '🔄 Edit scheduled toots',
           description: 'Made a typo? No problem! Now you can edit your scheduled toots!',
+        },
+      ],
+    },
+    {
+      version: '0.5.8',
+      date: '2024-03-19',
+      features: [
+        {
+          id: 'header-layout-fix',
+          title: '📱 Header layout fix',
+          description: 'Fixed the header layout to be more responsive on mobile devices!',
         },
       ],
     },


### PR DESCRIPTION
# Add Edit Functionality for Scheduled Toots

## Problem Statement
Initially, our application only supported creating and deleting scheduled toots. Users needed the ability to edit their scheduled toots, but the Mastodon API has a limitation where direct content updates to scheduled toots are not supported.

## Solution Overview
We implemented a workaround that maintains a good user experience while working within the Mastodon API's constraints. The solution involves:
1. Deleting the existing scheduled toot
2. Creating a new scheduled toot with the updated content and settings

## Technical Implementation

### Store Changes (`src/stores/scheduledToots.ts`)
- Added `editingToot` state to track the toot being edited
- Implemented `setEditingToot` action to manage edit mode
- Modified `updateToot` action to handle the delete-and-recreate pattern:
  ```typescript
  async updateToot(id: string, updatedToot: ScheduledToot) {
    try {
      this.setLoading(true);
      const api = useMastodonApi();
      await api.deleteScheduledToot(id);
      await api.scheduleToot(updatedToot);
      await this.fetchScheduledToots();
      this.setEditingToot(null);
    } catch (err) {
      // Error handling...
    }
  }
  ```

### API Layer Changes (`src/composables/useMastodonApi.ts`)
- Enhanced `scheduleToot` function with improved payload handling:
  ```typescript
  const payload = {
    status: toot.status,
    scheduled_at: toot.scheduled_at,
    media_ids: toot.media_ids || [],
    visibility: toot.visibility || 'public',
    sensitive: toot.sensitive || false,
    spoiler_text: toot.spoiler_text || '',
    language: toot.language || null,
    idempotency: Date.now().toString(),
  };
  ```
- Added default values for optional fields to ensure API compatibility
- Implemented idempotency key to prevent duplicate posts during network issues
- Uses the correct `/api/v1/statuses` endpoint with `scheduled_at` parameter for scheduling

## API Constraints
The Mastodon API (`/api/v1/scheduled_statuses/:id`) only allows:
- Viewing scheduled toots
- Updating the scheduled publishing date
- Canceling (deleting) scheduled toots

It does not support direct content updates, which led to our delete-and-recreate approach.

## Testing Considerations
When testing this feature, ensure:
1. The edit button correctly populates the form with existing toot data
2. All toot properties (content, visibility, media, etc.) are preserved when not modified
3. The scheduled date is correctly maintained or updated
4. No duplicate toots are created during the update process
5. Error states are properly handled and communicated to the user

## Future Improvements
1. Consider implementing optimistic updates to improve perceived performance
2. Add a confirmation dialog before updating to prevent accidental changes
3. Implement a retry mechanism for failed updates
4. Add ability to track edit history (if needed by product requirements)